### PR TITLE
Android build failure fix

### DIFF
--- a/android/src/main/java/com/galmis/rnbugfender/RNBugfenderPackage.java
+++ b/android/src/main/java/com/galmis/rnbugfender/RNBugfenderPackage.java
@@ -24,7 +24,6 @@ public class RNBugfenderPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
remove override statement on createJSModules because it no longer exists on RN > 0.4